### PR TITLE
Change non-existing 'build-essentials' to correct package

### DIFF
--- a/book/1 - Installing/2 - Compiling MCServer Yourself.html
+++ b/book/1 - Installing/2 - Compiling MCServer Yourself.html
@@ -12,7 +12,7 @@
 	Compiling on Linux and related operating systems is easy and simple, although it does require some tools before you can get started. You need a C++ compiler (Clang++ or G++), a C compiler (Clang or GCC), Git, CMake and Make. A simple command to make sure these tools are installed (Ubuntu/Debian) is:
 </b>
 
-<pre><code>sudo apt-get install clang git cmake build-essentials</code></pre>
+<pre><code>sudo apt-get install clang git cmake build-essential</code></pre>
 
 <p>
 	Once the tools are installed, you should clone the Git repo:


### PR DESCRIPTION
Just found this little error when trying to install the dependencies ^^