### PR TITLE
Make git commands work

### DIFF
--- a/book/1 - Installing/2 - Compiling MCServer Yourself.html
+++ b/book/1 - Installing/2 - Compiling MCServer Yourself.html
@@ -19,7 +19,8 @@
 </p>
 
 <pre><code>git clone https://github.com/mc-server/MCServer.git
-git submodule init --update
+cd MCServer
+git submodule update --init
 </code></pre>
 
 <p>


### PR DESCRIPTION
`git submodule init --update` is not a valid command, `git submodule update --init` does work. For that to work you have to be inside the cloned repository however, so a `cd MCServer` is needed too.